### PR TITLE
Shorten taskid

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,5 @@
+image: scrapinghub
+
+script:
+  - build_docker_image
+  - push_docker_image

--- a/collectd_marathon_plugin.py
+++ b/collectd_marathon_plugin.py
@@ -217,7 +217,11 @@ class ContainerStats(threading.Thread):
 
         if app and task:
             self._container['App'] = app
-            self._container['Task'] = task[len(app)+1:]
+            # Task ID: appID_{8chars}-{4chars}-{4chars}-{4chars}-{12chars}
+            # Regex  : appID_[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}
+            # Example: splash-brandview-keywords_web_cf4e7639-aeb4-11e5-ad74-56847afe9799
+            # First 8 chars are unique to every task, related to launch time (seconds)
+            self._container['Task'] = task[len(app)+1:len(app)+9]
         else:
             # We're not interested in non-marathon containers
             self.stop = True


### PR DESCRIPTION
Task ID has the following form appID_{8chars}-{4chars}-{4chars}-{4chars}-{12chars}
We can define it with the following regex appID_[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}

An example is: splash-brandview-keywords_web_cf4e7639-aeb4-11e5-ad74-56847afe9799
The first 8 characters are unique to every task, and it's related to the launch time, so every task launched at the same day/hour/min would have the same suffix -{4chars}-{4chars}-{4chars}-{12chars}

So we can identify each task with its first 8 chars thus reducing the size of taskID to just 8 chars.
