### PR TITLE
Export Kumo metrics to OpenTSDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,3 @@ ADD metrics.db /usr/share/collectd/plugins/mesos/
 # Add entrypoint script
 ADD bin/run.sh /run.sh
 ENTRYPOINT ["/run.sh"]
-VOLUME /var/log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.3
 
 RUN apk --update add collectd collectd-python py-pip
 
@@ -10,6 +10,7 @@ ADD collectd.conf.tpl /etc/collectd/collectd.conf.tpl
 
 # Add metrics collector
 ADD collectd_mesos_plugin.py /usr/share/collectd/plugins/mesos/
+ADD collectd_opentsdb_plugin.py /usr/share/collectd/plugins/mesos/
 
 # Add metrics db
 ADD metrics.db /usr/share/collectd/plugins/mesos/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,12 @@ RUN pip install -r /requirements.txt
 ADD collectd.conf.tpl /etc/collectd/collectd.conf.tpl
 
 # Add metrics collector
-ADD collectd_marathon_plugin.py /usr/share/collectd/plugins/marathon/
+ADD collectd_mesos_plugin.py /usr/share/collectd/plugins/mesos/
 
 # Add metrics db
-ADD metrics.db /usr/share/collectd/plugins/marathon/
+ADD metrics.db /usr/share/collectd/plugins/mesos/
 
 # Add entrypoint script
 ADD bin/run.sh /run.sh
 ENTRYPOINT ["/run.sh"]
+VOLUME /var/log

--- a/collectd.conf.tpl
+++ b/collectd.conf.tpl
@@ -57,6 +57,6 @@ PostCacheChain "PostCache"
         Target stop
     </Rule>
     <Target "write">
-        Plugin "write_graphite"
+        Plugin "write_graphite/carbon"
     </Target>
 </Chain>

--- a/collectd.conf.tpl
+++ b/collectd.conf.tpl
@@ -7,7 +7,7 @@ ReadThreads 5
 
 LoadPlugin write_graphite
 <Plugin "write_graphite">
-    <Carbon>
+    <Node "carbon">
         Host "{{ GRAPHITE_HOST }}"
         Port "{{ GRAPHITE_PORT | default("2003") }}"
         Protocol "tcp"
@@ -16,7 +16,7 @@ LoadPlugin write_graphite
         StoreRates true
         AlwaysAppendDS false
         SeparateInstances true
-    </Carbon>
+    </Node>
 </Plugin>
 
 TypesDB "/usr/share/collectd/plugins/mesos/metrics.db"
@@ -49,14 +49,14 @@ PostCacheChain "PostCache"
     <Rule>
         <Match regex>
             Plugin "mesos-tasks"
-            PluginInstance "^(!kumo)"
+            PluginInstance "^(kumo\.)"
         </Match>
         <Target "write">
-            Plugin "write_graphite"
+            Plugin "python.write_opentsdb"
         </Target>
         Target stop
     </Rule>
     <Target "write">
-        Plugin "python.write_opentsdb"
+        Plugin "write_graphite"
     </Target>
 </Chain>

--- a/collectd.conf.tpl
+++ b/collectd.conf.tpl
@@ -4,26 +4,26 @@ FQDNLookup false
 Interval {{ COLLECTD_INTERVAL | default(10) }}
 Timeout 2
 ReadThreads 5
-TypesDB "/usr/share/collectd/plugins/mesos/metrics.db"
-
-
 
 LoadPlugin write_graphite
+<Plugin "write_graphite">
+    <Carbon>
+        Host "{{ GRAPHITE_HOST }}"
+        Port "{{ GRAPHITE_PORT | default("2003") }}"
+        Protocol "tcp"
+        Prefix "{{ GRAPHITE_PREFIX | default("collectd.") }}"
+        EscapeCharacter "."
+        StoreRates true
+        AlwaysAppendDS false
+        SeparateInstances true
+    </Carbon>
+</Plugin>
+
+TypesDB "/usr/share/collectd/plugins/mesos/metrics.db"
+
 <LoadPlugin "python">
     Globals true
 </LoadPlugin>
-
-<Plugin "write_graphite">
-    Host "{{ GRAPHITE_HOST }}"
-    Port "{{ GRAPHITE_PORT | default("2003") }}"
-    Protocol "tcp"
-    Prefix "{{ GRAPHITE_PREFIX | default("collectd.") }}"
-    EscapeCharacter "."
-    StoreRates true
-    AlwaysAppendDS false
-    SeparateInstances true
-</Plugin>
-
 <Plugin "python">
     ModulePath "/usr/share/collectd/plugins/mesos"
     LogTraces true

--- a/collectd_mesos_plugin.py
+++ b/collectd_mesos_plugin.py
@@ -223,19 +223,18 @@ class ContainerStats(threading.Thread):
                 kumo_job = value.split('/')[:3]
 
         # FIXME we can use environment variable or rely on image name
-        image = details.get('Config', {}).get('Image')
-        if app and task:
+        if kumo_job:
+            self._container['App'] = 'kumo'
+            self._container['Project'] = kumo_job[0]
+            self._container['Spider'] = kumo_job[1]
+            self._container['Job'] = kumo_job[2]
+        elif app and task:
             self._container['App'] = app
             # Task ID: appID_{8chars}-{4chars}-{4chars}-{4chars}-{12chars}
             # Regex  : appID_[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}
             # Example: splash-brandview-keywords_web_cf4e7639-aeb4-11e5-ad74-56847afe9799
             # First 8 chars are unique to every task, related to launch time (seconds)
             self._container['Task'] = task[len(app)+1:len(app)+9]
-        elif kumo_job:
-            self._container['App'] = 'kumo'
-            self._container['Project'] = kumo_job[0]
-            self._container['Spider'] = kumo_job[1]
-            self._container['Job'] = kumo_job[2]
         else:
             # We're not interested in other mesos containers
             self.stop = True
@@ -350,6 +349,7 @@ class DockerPlugin:
                       .format(url=self.docker_url,
                               version=version,
                               timeout=self.timeout))
+
         return True
 
     def read_callback(self):

--- a/collectd_mesos_plugin.py
+++ b/collectd_mesos_plugin.py
@@ -219,7 +219,7 @@ class ContainerStats(threading.Thread):
 
         if kumo_job:
             self._container['App'] = 'kumo'
-            self._container['Task'] = kumo_job
+            self._container['Task'] = kumo_job.replace('/', '.')
         elif app and task:
             self._container['App'] = app
             # Task ID: appID_{8chars}-{4chars}-{4chars}-{4chars}-{12chars}

--- a/collectd_mesos_plugin.py
+++ b/collectd_mesos_plugin.py
@@ -217,7 +217,6 @@ class ContainerStats(threading.Thread):
             if name == 'SHUB_JOBKEY':
                 kumo_job = value
 
-        # FIXME we can use environment variable or rely on image name
         if kumo_job:
             self._container['App'] = 'kumo'
             self._container['Task'] = kumo_job
@@ -342,7 +341,6 @@ class DockerPlugin:
                       .format(url=self.docker_url,
                               version=version,
                               timeout=self.timeout))
-
         return True
 
     def read_callback(self):

--- a/collectd_mesos_plugin.py
+++ b/collectd_mesos_plugin.py
@@ -52,13 +52,8 @@ class Stats:
         val = collectd.Values()
         val.plugin = 'mesos-tasks'
         if 'App' in container:
-            if container['App'] == 'kumo':
-                val.plugin_instance = "{}.{}.{}.{}".format(
-                    container['App'], container['Project'],
-                    container['Spider'], container['Job'])
-            else:
-                val.plugin_instance = "{}.{}".format(
-                    container['App'], container['Task'])
+            val.plugin_instance = "{}.{}".format(
+                container['App'], container['Task'])
         else:
             return
 
@@ -219,15 +214,13 @@ class ContainerStats(threading.Thread):
                 app = (value[1:]).replace(".", "_").replace('/', '_')
             if name == 'MESOS_TASK_ID':
                 task = value.replace(".", "_")
-            if name == 'KUMO_JOB_ID':
-                kumo_job = value.split('/')[:3]
+            if name == 'SHUB_JOBKEY':
+                kumo_job = value
 
         # FIXME we can use environment variable or rely on image name
         if kumo_job:
             self._container['App'] = 'kumo'
-            self._container['Project'] = kumo_job[0]
-            self._container['Spider'] = kumo_job[1]
-            self._container['Job'] = kumo_job[2]
+            self._container['Task'] = kumo_job
         elif app and task:
             self._container['App'] = app
             # Task ID: appID_{8chars}-{4chars}-{4chars}-{4chars}-{12chars}

--- a/collectd_mesos_plugin.py
+++ b/collectd_mesos_plugin.py
@@ -50,9 +50,15 @@ class Stats:
     @classmethod
     def emit(cls, container, type, value, t=None, type_instance=None):
         val = collectd.Values()
-        val.plugin = 'mesos-marathon-tasks'
+        val.plugin = 'mesos-tasks'
         if 'App' in container:
-            val.plugin_instance = "{}.{}".format(container['App'], container['Task'])
+            if container['App'] == 'kumo':
+                val.plugin_instance = "{}.{}.{}.{}".format(
+                    container['App'], container['Project'],
+                    container['Spider'], container['Job'])
+            else:
+                val.plugin_instance = "{}.{}".format(
+                    container['App'], container['Task'])
         else:
             return
 
@@ -205,16 +211,19 @@ class ContainerStats(threading.Thread):
 
         # Get container inspect info and get marathon app and mesos task ids
         details = self._client.inspect_container(self._container['Id'])
-        app = None
-        task = None
+        app, task, kumo_job = None, None, None
         env = details.get('Config', {}).get('Env', [])
         for var in env:
-            name, value = var.split('=')
+            name, value = var.split('=')[:2]
             if name == 'MARATHON_APP_ID':
                 app = (value[1:]).replace(".", "_").replace('/', '_')
             if name == 'MESOS_TASK_ID':
                 task = value.replace(".", "_")
+            if name == 'KUMO_JOB_ID':
+                kumo_job = value.split('/')[:3]
 
+        # FIXME we can use environment variable or rely on image name
+        image = details.get('Config', {}).get('Image')
         if app and task:
             self._container['App'] = app
             # Task ID: appID_{8chars}-{4chars}-{4chars}-{4chars}-{12chars}
@@ -222,8 +231,13 @@ class ContainerStats(threading.Thread):
             # Example: splash-brandview-keywords_web_cf4e7639-aeb4-11e5-ad74-56847afe9799
             # First 8 chars are unique to every task, related to launch time (seconds)
             self._container['Task'] = task[len(app)+1:len(app)+9]
+        elif kumo_job:
+            self._container['App'] = 'kumo'
+            self._container['Project'] = kumo_job[0]
+            self._container['Spider'] = kumo_job[1]
+            self._container['Job'] = kumo_job[2]
         else:
-            # We're not interested in non-marathon containers
+            # We're not interested in other mesos containers
             self.stop = True
 
         failures = 0

--- a/collectd_mesos_plugin.py
+++ b/collectd_mesos_plugin.py
@@ -209,7 +209,7 @@ class ContainerStats(threading.Thread):
         app, task, kumo_job = None, None, None
         env = details.get('Config', {}).get('Env', [])
         for var in env:
-            name, value = var.split('=')[:2]
+            name, value = var.split('=', 1)
             if name == 'MARATHON_APP_ID':
                 app = (value[1:]).replace(".", "_").replace('/', '_')
             if name == 'MESOS_TASK_ID':

--- a/collectd_opentsdb_plugin.py
+++ b/collectd_opentsdb_plugin.py
@@ -18,17 +18,18 @@ class OpenTSDBExportPlugin:
                 self._opentsdb_port = value
         if not self._opentsdb_host or not self._opentsdb_port:
             raise Exception("OpenTSDB export plugin is not configured")
-        collectd.info("Configured OpenTSDB export plugin.")
+        collectd.info("Configured OpenTSDB export plugin (%s:%s)" %
+                      (self._opentsdb_host, self._opentsdb_port))
 
     def init_callback(self):
-        self.metrics = potsdb.Client(
-            host=self._opentsdb_host,
-            port=self._opentsdb_port,
-            host_tag=True, mps=100, check_host=True)
+        self.metrics = potsdb.Client(host=self._opentsdb_host,
+                                     port=self._opentsdb_port,
+                                     mps=100, check_host=True)
         collectd.info("Initialized OpenTSDB export plugin.")
-        return True
 
     def write_callback(self, vl):
+        if not self.metrics:
+            return
         metric_name = '{}.{}'.format(vl.type, vl.type_instance)
         tags = {'timestamp': vl.time}
         if vl.plugin_instance.startswith('kumo.'):
@@ -48,7 +49,7 @@ class OpenTSDBExportPlugin:
 
 
 if __name__ == '__main__':
-    print "OpenTSDB is called as a python script"
+    print "OpenTSDB export plugin is called as a python script"
 else:
     try:
         plugin = OpenTSDBExportPlugin()

--- a/collectd_opentsdb_plugin.py
+++ b/collectd_opentsdb_plugin.py
@@ -24,7 +24,8 @@ class OpenTSDBExportPlugin:
     def init_callback(self):
         self.metrics = potsdb.Client(host=self._opentsdb_host,
                                      port=self._opentsdb_port,
-                                     mps=100, check_host=True)
+                                     mps=100, check_host=True,
+                                     backoff=5)
         collectd.info("Initialized OpenTSDB export plugin.")
 
     def write_callback(self, vl):

--- a/collectd_opentsdb_plugin.py
+++ b/collectd_opentsdb_plugin.py
@@ -24,7 +24,7 @@ class OpenTSDBExportPlugin:
     def init_callback(self):
         self.metrics = potsdb.Client(host=self._opentsdb_host,
                                      port=self._opentsdb_port,
-                                     mps=100, check_host=True,
+                                     mps=100, check_host=False,
                                      backoff=5)
         collectd.info("Initialized OpenTSDB export plugin.")
 

--- a/collectd_opentsdb_plugin.py
+++ b/collectd_opentsdb_plugin.py
@@ -1,0 +1,55 @@
+import os
+import potsdb
+import collectd
+
+
+class OpenTSDBExportPlugin:
+
+    def __init__(self):
+        self.metrics = None
+
+    def configure_callback(self, conf):
+        for node in conf.children:
+            key = node.key.lower()
+            value = node.values[0]
+            if key == 'host':
+                self._opentsdb_host = value
+            elif key == 'port':
+                self._opentsdb_port = value
+        if not self._opentsdb_host or not self._opentsdb_port:
+            raise Exception("OpenTSDB export plugin is not configured")
+        collectd.info("Configured OpenTSDB export plugin.")
+
+    def init_callback(self):
+        self.metrics = potsdb.Client(
+            host=self._opentsdb_host,
+            port=self._opentsdb_port,
+            host_tag=True, mps=100, check_host=True)
+        collectd.info("Initialized OpenTSDB export plugin.")
+        return True
+
+    def write_callback(self, vl):
+        for value in vl.values:
+            if isinstance(value, (float, int)):
+                self.metrics.send(vl.plugin_instance, value,
+                                  type_instance=vl.type_instance,
+                                  type=vl.type)
+
+    def shutdown_callback(self):
+        if self.metrics:
+            self.metrics.wait()
+        collectd.info("Shutdown-ed OpenTSDB export plugin.")
+
+
+if __name__ == '__main__':
+    print "OpenTSDB is called as a python script"
+else:
+    try:
+        plugin = OpenTSDBExportPlugin()
+        collectd.register_config(plugin.configure_callback)
+        collectd.register_init(plugin.init_callback)
+        collectd.register_write(plugin.write_callback, name='write_opentsdb')
+        collectd.register_shutdown(plugin.shutdown_callback)
+        print "OpenTSDB export plugin is registered."
+    except Exception as ex:
+        print "OpenTSDB export plugin exception: %s" % ex

--- a/collectd_opentsdb_plugin.py
+++ b/collectd_opentsdb_plugin.py
@@ -29,11 +29,17 @@ class OpenTSDBExportPlugin:
         return True
 
     def write_callback(self, vl):
+        metric_name = '{}.{}'.format(vl.type, vl.type_instance)
+        tags = {'timestamp': vl.time}
+        if vl.plugin_instance.startswith('kumo.'):
+            project, spider, job = vl.plugin_instance.split('.')[1:]
+            tags.update({'project': project,
+                         'spider': spider,
+                         'job': job,
+                         'task': vl.plugin_instance[5:]})
         for value in vl.values:
             if isinstance(value, (float, int)):
-                self.metrics.send(vl.plugin_instance, value,
-                                  type_instance=vl.type_instance,
-                                  type=vl.type)
+                self.metrics.send(metric_name, value, **tags)
 
     def shutdown_callback(self):
         if self.metrics:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ envtpl
 py-dateutil
 docker-py>=1.0.0
 # potsdb==1.0.2 disabled in favor of the fork with connection backoff feature
--e git+git@github.com:scrapinghub/potsdb.git@feature-add-connection-backoff#egg=potsdb
+-e git+https://github.com/scrapinghub/potsdb.git@feature-add-connection-backoff#egg=potsdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ envtpl
 py-dateutil
 docker-py>=1.0.0
 # potsdb==1.0.2 disabled in favor of the fork with connection backoff feature
--e git+https://github.com/scrapinghub/potsdb.git@feature-add-connection-backoff#egg=potsdb
+https://github.com/scrapinghub/potsdb/archive/feature-add-connection-backoff.zip#egg=potsdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 envtpl
 py-dateutil
 docker-py>=1.0.0
-potsdb==1.0.2
+# potsdb==1.0.2 disabled in favor of the fork with connection backoff feature
+-e git+git@github.com:scrapinghub/potsdb.git@feature-add-connection-backoff#egg=potsdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 envtpl
 py-dateutil
 docker-py>=1.0.0
+potsdb==1.0.2


### PR DESCRIPTION
The PR extends logic of getting data from Mesos tasks and exports Kumo jobs metrics to OpenTSDB.

It contains the following changes:
- additional python plugin to write to OpenTSDB based on `potsdb` python lib
- improved collectd config to separate data flows (Marathon data->Graphite, Kumo data->OpenTSDB)
- renamed main python plugin as now we handle not only Marathon containers
- updated base docker image to work with newer collectd version (the previos version has a bug preventing correct work with collectd filter chains + python)

Don't merge pls, WIP, the PR is for review.

JIRA https://scrapinghub.atlassian.net/browse/SC-321

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/scrapinghub/marathon-apps-collectd-plugin/2)

<!-- Reviewable:end -->
