### PR TITLE
Add logfile plugin to collectd configuration

### DIFF
--- a/collectd.conf.tpl
+++ b/collectd.conf.tpl
@@ -6,6 +6,14 @@ Interval {{ COLLECTD_INTERVAL | default(10) }}
 Timeout 2
 ReadThreads 5
 
+LoadPlugin logfile
+<Plugin "logfile">
+    LogLevel "warning"
+    File "stdout"
+    Timestamp true
+    PrintSeverity true
+</Plugin>
+
 LoadPlugin write_graphite
 <Plugin "write_graphite">
     <Node "carbon">


### PR DESCRIPTION
When no logging plugin is configured, collectd will output all its messages to stderr. The amount of messages in the default `info` level is excessive so this changes it to `warning` where only problems are logged.